### PR TITLE
Changed verbose logging of written messages to debug level

### DIFF
--- a/src/main/java/org/freedesktop/dbus/MessageWriter.java
+++ b/src/main/java/org/freedesktop/dbus/MessageWriter.java
@@ -44,7 +44,7 @@ public class MessageWriter implements Closeable {
     }
 
     public void writeMessage(Message m) throws IOException {
-        logger.info("<= {}", m);
+        logger.debug("<= {}", m);
         if (null == m) {
             return;
         }


### PR DESCRIPTION
The _MessageWriter.writeMessage_ method logged each message in log level info which is very verbose. Changed log level to debug.